### PR TITLE
Fixed canHandle method.

### DIFF
--- a/component/src/main/java/org/wso2/carbon/identity/authenticator/office365/Office365Authenticator.java
+++ b/component/src/main/java/org/wso2/carbon/identity/authenticator/office365/Office365Authenticator.java
@@ -156,23 +156,6 @@ public class Office365Authenticator extends OpenIDConnectAuthenticator implement
     }
 
     /**
-     * Check whether the authentication or logout request can be handled by the authenticator
-     */
-    @Override
-    public boolean canHandle(HttpServletRequest request) {
-
-        if (request.getParameter(Office365AuthenticatorConstants.CODE) != null &&
-                Office365AuthenticatorConstants.AUTHENTICATOR_NAME.equals(
-                        request.getParameter(Office365AuthenticatorConstants.PARAM_AUTHENTICATOR)) &&
-                Office365AuthenticatorConstants.AUTHENTICATOR_FRIENDLY_NAME.equals(
-                        request.getParameter(Office365AuthenticatorConstants.PARAM_IDP))) {
-            return true;
-        }
-
-        return false;
-    }
-
-    /**
      * Authenticator flow process
      */
     @Override

--- a/component/src/main/java/org/wso2/carbon/identity/authenticator/office365/Office365Authenticator.java
+++ b/component/src/main/java/org/wso2/carbon/identity/authenticator/office365/Office365Authenticator.java
@@ -159,8 +159,17 @@ public class Office365Authenticator extends OpenIDConnectAuthenticator implement
      * Check whether the authentication or logout request can be handled by the authenticator
      */
     @Override
-    public boolean canHandle(HttpServletRequest arg0) {
-        return true;
+    public boolean canHandle(HttpServletRequest request) {
+
+        if (request.getParameter(Office365AuthenticatorConstants.CODE) != null &&
+                Office365AuthenticatorConstants.AUTHENTICATOR_NAME.equals(
+                        request.getParameter(Office365AuthenticatorConstants.PARAM_AUTHENTICATOR)) &&
+                Office365AuthenticatorConstants.AUTHENTICATOR_FRIENDLY_NAME.equals(
+                        request.getParameter(Office365AuthenticatorConstants.PARAM_IDP))) {
+            return true;
+        }
+
+        return false;
     }
 
     /**

--- a/component/src/main/java/org/wso2/carbon/identity/authenticator/office365/Office365AuthenticatorConstants.java
+++ b/component/src/main/java/org/wso2/carbon/identity/authenticator/office365/Office365AuthenticatorConstants.java
@@ -55,4 +55,8 @@ public class Office365AuthenticatorConstants {
     public static final String BEARER = "Bearer ";
     //A randomly generated non-reused value that is sent in the request and returned in the response.
     public static final String STATE = "state";
+    //The authenticator that the application requested.
+    public static final String PARAM_AUTHENTICATOR = "authenticator";
+    //The idp that the application requested.
+    public static final String PARAM_IDP = "idp";
 }

--- a/component/src/main/java/org/wso2/carbon/identity/authenticator/office365/Office365AuthenticatorConstants.java
+++ b/component/src/main/java/org/wso2/carbon/identity/authenticator/office365/Office365AuthenticatorConstants.java
@@ -55,8 +55,4 @@ public class Office365AuthenticatorConstants {
     public static final String BEARER = "Bearer ";
     //A randomly generated non-reused value that is sent in the request and returned in the response.
     public static final String STATE = "state";
-    //The authenticator that the application requested.
-    public static final String PARAM_AUTHENTICATOR = "authenticator";
-    //The idp that the application requested.
-    public static final String PARAM_IDP = "idp";
 }


### PR DESCRIPTION
## Purpose
> Office365 authenticator overrides the local basic authenticator in WSO2 IS. Issue is always returning true by canHandle method.

## Goals
> Changed canHandle method to return true when only Office365 authenticator is requested.

## Approach
> Checked the authenticator type and return true only when authenticator type is equals to Office365.

## User stories
> When a user needs to login through the basic authenticat

## Release note
> Basic authentication flow works properly when Office365 is a federated authenticator.

## Documentation
> N/A

## Training
> N/A

## Certification
> N/A

## Marketing
> N/A

## Automation tests
> N/A

## Security checks
> N/A

## Samples
> N/A

## Related PRs
> N/A

## Migrations (if applicable)
> N/A

## Test environment
> N/A
 
## Learning
> N/A