### PR TITLE
ISCONNECT-100 : Avoid overriding basic authentication by Office365

### DIFF
--- a/component/src/main/java/org/wso2/carbon/identity/authenticator/office365/Office365Authenticator.java
+++ b/component/src/main/java/org/wso2/carbon/identity/authenticator/office365/Office365Authenticator.java
@@ -156,6 +156,30 @@ public class Office365Authenticator extends OpenIDConnectAuthenticator implement
     }
 
     /**
+     * Check whether the authentication or logout request can be handled by the authenticator
+     */
+    @Override
+    public boolean canHandle(HttpServletRequest request) {
+
+        if (request.getParameter(Office365AuthenticatorConstants.CODE) != null &&
+                request.getParameter(OIDCAuthenticatorConstants.OAUTH2_PARAM_STATE) != null &&
+                Office365AuthenticatorConstants.AUTHENTICATOR_FRIENDLY_NAME.equals(getLoginType(request))) {
+            return true;
+        }
+
+        return false;
+    }
+
+    protected String getLoginType(HttpServletRequest request) {
+        String state = request.getParameter(OIDCAuthenticatorConstants.OAUTH2_PARAM_STATE);
+        if (state != null) {
+            return state.split(",")[1];
+        } else {
+            return null;
+        }
+    }
+
+    /**
      * Authenticator flow process
      */
     @Override
@@ -186,7 +210,8 @@ public class Office365Authenticator extends OpenIDConnectAuthenticator implement
         String clientId = authenticatorProperties.get(OIDCAuthenticatorConstants.CLIENT_ID);
         String redirectUri = authenticatorProperties.get(Office365AuthenticatorConstants.CALLBACK_URL);
         String loginPage = getAuthorizationServerEndpoint(context.getAuthenticatorProperties());
-        String queryParams = Office365AuthenticatorConstants.STATE + "=" + context.getContextIdentifier();
+        String queryParams = Office365AuthenticatorConstants.STATE + "=" + context.getContextIdentifier()
+                + "," + Office365AuthenticatorConstants.AUTHENTICATOR_FRIENDLY_NAME;
         try {
             response.sendRedirect(response.encodeRedirectURL(loginPage + "?" + queryParams + "&" +
                     Office365AuthenticatorConstants.CLIENT_ID + "=" + clientId + "&" +
@@ -326,6 +351,5 @@ public class Office365Authenticator extends OpenIDConnectAuthenticator implement
         return builder.toString();
     }
 }
-
 
 


### PR DESCRIPTION
## Purpose
> Office365 authenticator overrides the local basic authenticator in WSO2 IS. Issue is always returning true by canHandle method.

## Goals
> Changed canHandle method to return true when only Office365 authenticator is requested.

## Approach
> Checked the authenticator type and return true only when authenticator type is equals to Office365.

## User stories
> When a user needs to login through the basic authenticator.

## Release note
>  Basic authentication flow works properly when Office365 is a federated authenticator.

## Documentation
> N/A

## Training
> N/A

## Certification
> N/A

## Marketing
> 

## Automation tests
 N/A

## Security checks
N/A

## Samples
> N/A

## Related PRs
> N/A

## Migrations (if applicable)
> N/A

## Test environment
> N/A
 
## Learning
> N/A