### PR TITLE
Send Dynamic query parameters to federated authenticator endpoint

### DIFF
--- a/component/src/main/java/org/wso2/carbon/identity/authenticator/office365/Office365AuthenticatorConstants.java
+++ b/component/src/main/java/org/wso2/carbon/identity/authenticator/office365/Office365AuthenticatorConstants.java
@@ -58,4 +58,8 @@ public class Office365AuthenticatorConstants {
     public static final String ERROR = "error: ";
     public static final String ERROR_DESCRIPTION = ", error_description: ";
     public static final String STATE = ", state: ";
+    //A randomly generated non-reused value that is sent in the request and returned in the response.
+//    public static final String STATE = "state";
+    //Additional Query Parameters that need to be sent to IDP
+    public static final String ADDITIONAL_QUERY_PARAMS = "AdditionalQueryParameters";
 }


### PR DESCRIPTION
With this we can configure **Additional Query Parameters:** that need to be sent to federated authentication endpoint as shown below.

![office365_additionalparams](https://user-images.githubusercontent.com/5061791/36736905-bda8fbca-1bff-11e8-93ca-9affacdf5abd.png)

Can parameterize the values by mentioning with parenthesis "{}" and then, query parameter value will be populated from the initial authentication request to identity server. 

ex: 
Request to identity server: https://localhost:9443/oauth2/authorize?grant=authorization_code&redirect_uri=http://localhost/callback&client_id=lY0Q9kwI_xjId1YZhfpda2Nvny4a&response_type=code&username=ayesha

Additional Query Parameters: username={username}&login_hint={username}

Request to Office356 authentication endpoint: https://login.microsoftonline.com/common/oauth2/authorize?**login_hint=ayesha&username=ayesha**&state=b014e4fc-4ea0-4c7b-bb28-8dd94c843009,Office365&client_id=gywduqgduq&response_type=code&redirect_uri=&resource=https://outlook.office.com

Resolves: https://github.com/wso2/product-is/issues/2693