### PR TITLE
Update parent groupId and change to next development version in master branch

### DIFF
--- a/component/pom.xml
+++ b/component/pom.xml
@@ -16,13 +16,13 @@
 -->
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
     <parent>
-        <groupId>org.wso2.carbon.extension.identity.authenticator</groupId>
+        <groupId>org.wso2.carbon.extension.identity.authenticator.outbound.office365</groupId>
         <artifactId>org.wso2.carbon.extension.identity.authenticator.office365</artifactId>
-        <version>1.0.7-SNAPSHOT</version>
+        <version>2.0.0-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
     <artifactId>org.wso2.carbon.extension.identity.authenticator.office365.connector</artifactId>
-    <version>1.0.7-SNAPSHOT</version>
+    <version>2.0.0-SNAPSHOT</version>
     <packaging>bundle</packaging>
     <name>WSO2 Carbon - Authenticator Library For Office365</name>
     <url>http://wso2.org</url>

--- a/feature/pom.xml
+++ b/feature/pom.xml
@@ -17,19 +17,19 @@
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
     <modelVersion>4.0.0</modelVersion>
     <parent>
-        <groupId>org.wso2.carbon.extension.identity.authenticator</groupId>
+        <groupId>org.wso2.carbon.extension.identity.authenticator.outbound.office365</groupId>
         <artifactId>org.wso2.carbon.extension.identity.authenticator.office365</artifactId>
-        <version>1.0.7-SNAPSHOT</version>
+        <version>2.0.0-SNAPSHOT</version>
     </parent>
     <artifactId>org.wso2.carbon.extension.identity.authenticator.office365.feature</artifactId>
-    <version>1.0.7-SNAPSHOT</version>
+    <version>2.0.0-SNAPSHOT</version>
     <packaging>pom</packaging>
     <name>WSO2 Carbon - identity Office365 Feature</name>
     <url>http://wso2.org</url>
     <description>This feature contains extension feature for Office365</description>
     <dependencies>
         <dependency>
-            <groupId>org.wso2.carbon.extension.identity.authenticator</groupId>
+            <groupId>org.wso2.carbon.extension.identity.authenticator.outbound.office365</groupId>
             <artifactId>org.wso2.carbon.extension.identity.authenticator.office365.connector</artifactId>
             <version>${project.version}</version>
         </dependency>
@@ -59,7 +59,7 @@
                             </adviceFile>
                             <bundles>
                                 <bundleDef>
-                                    org.wso2.carbon.extension.identity.authenticator:org.wso2.carbon.extension.identity.authenticator.office365.connector
+                                    org.wso2.carbon.extension.identity.authenticator.outbound.office365:org.wso2.carbon.extension.identity.authenticator.office365.connector
                                 </bundleDef>
                             </bundles>
                         </configuration>

--- a/pom.xml
+++ b/pom.xml
@@ -23,9 +23,9 @@
         <artifactId>wso2</artifactId>
         <version>1</version>
     </parent>
-    <groupId>org.wso2.carbon.extension.identity.authenticator</groupId>
+    <groupId>org.wso2.carbon.extension.identity.authenticator.outbound.office365</groupId>
     <artifactId>org.wso2.carbon.extension.identity.authenticator.office365</artifactId>
-    <version>1.0.7-SNAPSHOT</version>
+    <version>2.0.0-SNAPSHOT</version>
     <packaging>pom</packaging>
     <name>WSO2 Carbon Extension - Office365 Pom</name>
     <url>http://wso2.org</url>


### PR DESCRIPTION
## Purpose
> Update the groupId of the parent in order to align with current naming convention used in outbound provisioning connectors and do a major release of the connector.