### PR TITLE
Fix Incorrectly Resolving Dynamic Parameters

### DIFF
--- a/component/src/main/java/org/wso2/carbon/identity/authenticator/office365/Office365Authenticator.java
+++ b/component/src/main/java/org/wso2/carbon/identity/authenticator/office365/Office365Authenticator.java
@@ -419,7 +419,7 @@ public class Office365Authenticator extends OpenIDConnectAuthenticator implement
     private String resolveDynamicParameter(AuthenticationContext context) {
 
         String queryParameters = context.getAuthenticatorProperties().get(Office365AuthenticatorConstants.ADDITIONAL_QUERY_PARAMS);
-        if (queryParameters != null) {
+        if (StringUtils.isNotBlank(queryParameters)) {
             String resolvedQueryParams = getResolvedQueryParams(context, queryParameters);
             context.getAuthenticatorProperties()
                     .put(Office365AuthenticatorConstants.ADDITIONAL_QUERY_PARAMS, resolvedQueryParams);
@@ -445,13 +445,12 @@ public class Office365Authenticator extends OpenIDConnectAuthenticator implement
                 String[] dynamicParam = context.getAuthenticationRequest()
                         .getRequestQueryParam(entry.getValue().substring(1, entry.getValue().length() - 1));
                 if (dynamicParam != null && dynamicParam.length > 0) {
-                    entry.setValue(dynamicParam[0]);
+                    if (queryBuilder.length() > 0) {
+                        queryBuilder.append('&');
+                    }
+                    queryBuilder.append(entry.getKey()).append(EQUAL).append(dynamicParam[0]);
                 }
             }
-            if (queryBuilder.length() > 0) {
-                queryBuilder.append('&');
-            }
-            queryBuilder.append(entry.getKey()).append(EQUAL).append(entry.getValue());
         }
         return queryBuilder.toString();
     }


### PR DESCRIPTION
## Purpose
When resolving dynamic parameters, if the query parameters specified by the user under additional parameters are not available in the authentication request, they will be appended to the redirect URL of the response in the same format. 
Ex: If the parameter `login_hint={username}&username={username}` is added as additional parameters and if the username is not available in the authentication request query params, then the response redirect URL will be formed as 
```
https://login.microsoftonline.com/common/oauth2/authorize?login_hint={username}&username={username}&state=b9a3b4ea-6256-462a-8474-89c52bfea7ce,Office365&client_id=397c5cc2-8e93-42bb-89d1-ab30da6bad48&response_type=code&redirect_uri=https://localhost:9443/commonauth&resource=https://graph.microsoft.com
```
And if the additional parameters field is left blank, the parameter will be added as an empty string and the string `=&` will be added to the redirect URL.

This PR will handle the above 2 scenarios and resolve an empty string instead of incorrect characters.

Resolves: https://github.com/wso2/product-is/issues/13790