### PR TITLE
[IS-7.1.0] Resolve proper commonauth URL for sub organizations when the property value is empty

### DIFF
--- a/component/pom.xml
+++ b/component/pom.xml
@@ -18,11 +18,11 @@
     <parent>
         <groupId>org.wso2.carbon.extension.identity.authenticator.outbound.office365</groupId>
         <artifactId>org.wso2.carbon.extension.identity.authenticator.office365</artifactId>
-        <version>2.1.7</version>
+        <version>2.1.7.1-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
     <artifactId>org.wso2.carbon.extension.identity.authenticator.office365.connector</artifactId>
-    <version>2.1.7</version>
+    <version>2.1.7.1-SNAPSHOT</version>
     <packaging>bundle</packaging>
     <name>WSO2 Carbon - Authenticator Library For Office365</name>
     <url>http://wso2.org</url>

--- a/component/pom.xml
+++ b/component/pom.xml
@@ -43,8 +43,8 @@
                 <artifactId>maven-compiler-plugin</artifactId>
                 <version>2.0</version>
                 <configuration>
-                    <source>1.7</source>
-                    <target>1.7</target>
+                    <source>1.8</source>
+                    <target>1.8</target>
                 </configuration>
             </plugin>
             <plugin>
@@ -66,6 +66,7 @@
                             org.wso2.carbon.identity.application.common.util;
                             version="${carbon.identity.framework.imp.pkg.version.range}",
                             org.wso2.carbon.identity.base; version="${carbon.identity.framework.imp.pkg.version.range}",
+                            org.wso2.carbon.identity.core; version="${carbon.identity.framework.imp.pkg.version.range}",
                             org.wso2.carbon.identity.core.util; version="${carbon.identity.framework.imp.pkg.version.range}",
                             javax.servlet,
                             javax.servlet.http,

--- a/component/src/main/java/org/wso2/carbon/identity/authenticator/office365/Office365Authenticator.java
+++ b/component/src/main/java/org/wso2/carbon/identity/authenticator/office365/Office365Authenticator.java
@@ -532,6 +532,7 @@ public class Office365Authenticator extends OpenIDConnectAuthenticator implement
      * @return the callback URL.
      * @throws IllegalStateException if the callback URL cannot be built.
      */
+    @Override
     protected String getCallbackUrl(Map<String, String> authenticatorProperties) {
 
         String callbackUrl = authenticatorProperties.get(Office365AuthenticatorConstants.CALLBACK_URL);

--- a/component/src/main/java/org/wso2/carbon/identity/authenticator/office365/Office365Authenticator.java
+++ b/component/src/main/java/org/wso2/carbon/identity/authenticator/office365/Office365Authenticator.java
@@ -537,7 +537,7 @@ public class Office365Authenticator extends OpenIDConnectAuthenticator implement
     protected String getCallbackUrl(Map<String, String> authenticatorProperties) {
 
         String callbackUrl = authenticatorProperties.get(Office365AuthenticatorConstants.CALLBACK_URL);
-        if (StringUtils.isNotEmpty(callbackUrl)) {
+        if (StringUtils.isNotBlank(callbackUrl)) {
             return callbackUrl;
         }
 

--- a/component/src/main/java/org/wso2/carbon/identity/authenticator/office365/Office365Authenticator.java
+++ b/component/src/main/java/org/wso2/carbon/identity/authenticator/office365/Office365Authenticator.java
@@ -563,7 +563,7 @@ public class Office365Authenticator extends OpenIDConnectAuthenticator implement
                 .getParameterMap()
                 .get(Office365AuthenticatorConstants.USE_ORG_SPECIFIC_COMMON_AUTH_URL);
 
-        return StringUtils.isNotBlank(value) && Boolean.parseBoolean(value);
+        return Boolean.parseBoolean(value);
     }
 
     /**

--- a/component/src/main/java/org/wso2/carbon/identity/authenticator/office365/Office365AuthenticatorConstants.java
+++ b/component/src/main/java/org/wso2/carbon/identity/authenticator/office365/Office365AuthenticatorConstants.java
@@ -62,4 +62,5 @@ public class Office365AuthenticatorConstants {
 //    public static final String STATE = "state";
     //Additional Query Parameters that need to be sent to IDP
     public static final String ADDITIONAL_QUERY_PARAMS = "AdditionalQueryParameters";
+    public static final String USE_ORG_SPECIFIC_COMMON_AUTH_URL = "UseOrgSpecificCommonAuthURL";
 }

--- a/feature/pom.xml
+++ b/feature/pom.xml
@@ -19,10 +19,10 @@
     <parent>
         <groupId>org.wso2.carbon.extension.identity.authenticator.outbound.office365</groupId>
         <artifactId>org.wso2.carbon.extension.identity.authenticator.office365</artifactId>
-        <version>2.1.7</version>
+        <version>2.1.7.1-SNAPSHOT</version>
     </parent>
     <artifactId>org.wso2.carbon.extension.identity.authenticator.office365.feature</artifactId>
-    <version>2.1.7</version>
+    <version>2.1.7.1-SNAPSHOT</version>
     <packaging>pom</packaging>
     <name>WSO2 Carbon - identity Office365 Feature</name>
     <url>http://wso2.org</url>

--- a/pom.xml
+++ b/pom.xml
@@ -25,7 +25,7 @@
     </parent>
     <groupId>org.wso2.carbon.extension.identity.authenticator.outbound.office365</groupId>
     <artifactId>org.wso2.carbon.extension.identity.authenticator.office365</artifactId>
-    <version>2.1.7</version>
+    <version>2.1.7.1-SNAPSHOT</version>
     <packaging>pom</packaging>
     <name>WSO2 Carbon Extension - Office365 Pom</name>
     <url>http://wso2.org</url>

--- a/pom.xml
+++ b/pom.xml
@@ -187,8 +187,8 @@
                 <version>2.3.1</version>
                 <configuration>
                     <encoding>UTF-8</encoding>
-                    <source>1.7</source>
-                    <target>1.7</target>
+                    <source>1.8</source>
+                    <target>1.8</target>
                 </configuration>
             </plugin>
             <plugin>


### PR DESCRIPTION
## Purpose
When configuring authenticators such as Office365, the default Callback URL uses the standard /commonauth endpoint instead of an organization-specific commonauth endpoint. However, for standard OIDC connections, the default is the organization-specific commonauth endpoint.

This fix resolves the problem by ensuring that, when the callback property is not explicitly set, the proper org-specific commonauth URL is derived and used consistently.

Fixes: https://github.com/wso2/product-is/issues/24753

## Goals
- Ensure consistent usage of org-specific commonauth endpoints across authenticators when the callback property is not explicitly set.
- Reduce customer confusion and align behavior of Office365 and OIDC connections.

## Approach
- Modified the callback URL resolution logic to derive the org-specific commonauth endpoint whenever the property value is empty.
- Added a fallback mechanism so that if an organization-specific path is applicable, it will be used instead of defaulting to /commonauth.

## User stories
As an administrator configuring Office365 or OIDC authenticators under sub-organizations, I need the system to automatically resolve the correct org-specific commonauth endpoint so that authentication flows work consistently without manual intervention.

## Release note
Fixed an issue where authenticators did not resolve the correct org-specific commonauth endpoint when the callback property was empty, causing inconsistent behavior across authenticators.

## Documentation
N/A – No documentation impact as this change aligns authenticator behavior with existing documented behavior for OIDC connections.

## Training
N/A – No new functionality introduced; this is a fix for consistency.

## Certification
N/A – This fix does not introduce new product features requiring certification updates.

## Marketing
N/A – Internal consistency fix; not customer-facing feature addition.

## Security checks
 - Followed secure coding standards in http://wso2.com/technical-reports/wso2-secure-engineering-guidelines? yes 
 - Ran FindSecurityBugs plugin and verified report? yes 
 - Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets? yes

## Samples
N/A – Fix applies to existing authentication flows; no new samples required.

## Migrations (if applicable)
N/A – No migration impact.

## Test environment
JDK 11
macOS Sonoma 14.4
Databases: H2