### PR TITLE
Resolve proper commonauth URL for sub organizations when the property value is empty

### DIFF
--- a/component/pom.xml
+++ b/component/pom.xml
@@ -43,8 +43,8 @@
                 <artifactId>maven-compiler-plugin</artifactId>
                 <version>2.0</version>
                 <configuration>
-                    <source>1.7</source>
-                    <target>1.7</target>
+                    <source>1.8</source>
+                    <target>1.8</target>
                 </configuration>
             </plugin>
             <plugin>
@@ -66,6 +66,7 @@
                             org.wso2.carbon.identity.application.common.util;
                             version="${carbon.identity.framework.imp.pkg.version.range}",
                             org.wso2.carbon.identity.base; version="${carbon.identity.framework.imp.pkg.version.range}",
+                            org.wso2.carbon.identity.core; version="${carbon.identity.framework.imp.pkg.version.range}",
                             org.wso2.carbon.identity.core.util; version="${carbon.identity.framework.imp.pkg.version.range}",
                             javax.servlet,
                             javax.servlet.http,

--- a/component/src/main/java/org/wso2/carbon/identity/authenticator/office365/Office365Authenticator.java
+++ b/component/src/main/java/org/wso2/carbon/identity/authenticator/office365/Office365Authenticator.java
@@ -45,6 +45,8 @@ import org.wso2.carbon.identity.application.common.model.ClaimMapping;
 import org.wso2.carbon.identity.application.common.model.Property;
 import org.wso2.carbon.identity.application.common.util.IdentityApplicationConstants;
 import org.wso2.carbon.identity.base.IdentityConstants;
+import org.wso2.carbon.identity.core.ServiceURLBuilder;
+import org.wso2.carbon.identity.core.URLBuilderException;
 import org.wso2.carbon.identity.core.util.IdentityUtil;
 
 import javax.servlet.http.HttpServletRequest;
@@ -58,7 +60,6 @@ import java.net.URL;
 import java.net.URLDecoder;
 import java.nio.charset.StandardCharsets;
 import java.util.ArrayList;
-import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.regex.Matcher;
@@ -266,10 +267,7 @@ public class Office365Authenticator extends OpenIDConnectAuthenticator implement
 
         Map<String, String> authenticatorProperties = context.getAuthenticatorProperties();
         String clientId = authenticatorProperties.get(OIDCAuthenticatorConstants.CLIENT_ID);
-        String redirectUri = authenticatorProperties.get(Office365AuthenticatorConstants.CALLBACK_URL);
-        if (StringUtils.isBlank(redirectUri)) {
-            redirectUri = IdentityUtil.getServerURL(FrameworkConstants.COMMONAUTH, true, true);
-        }
+        String redirectUri = getCallbackUrl(authenticatorProperties);
         String loginPage = getAuthorizationServerEndpoint(context.getAuthenticatorProperties());
         String identifierParam = OIDCAuthenticatorConstants.OAUTH2_PARAM_STATE + EQUAL + context.getContextIdentifier()
                 + "," + Office365AuthenticatorConstants.AUTHENTICATOR_FRIENDLY_NAME;
@@ -525,6 +523,65 @@ public class Office365Authenticator extends OpenIDConnectAuthenticator implement
         }
         return StringUtils.EMPTY;
     }
+
+    /**
+     * Resolves the callback URL from the authenticator properties. If a callback URL is provided, that value is
+     * returned. If empty, returns the global commonauth endpoint when organization-specific commonauth is disabled,
+     * or otherwise the organization-specific commonauth endpoint.
+     *
+     * @param authenticatorProperties the authenticator properties map.
+     * @return the resolved callback URL.
+     * @throws RuntimeException if building the callback URL fails.
+     */
+    @Override
+    protected String getCallbackUrl(Map<String, String> authenticatorProperties) {
+
+        String callbackUrl = authenticatorProperties.get(Office365AuthenticatorConstants.CALLBACK_URL);
+        if (StringUtils.isNotBlank(callbackUrl)) {
+            return callbackUrl;
+        }
+
+        if (!isOrgSpecificCommonAuthURLEnabled()) {
+            return IdentityUtil.getServerURL(FrameworkConstants.COMMONAUTH, true, true);
+        }
+
+        return buildOrgSpecificCommonAuthURL();
+    }
+
+    /**
+     * Returns whether the organization-specific commonauth endpoint is enabled in the authenticator parameters.
+     *
+     * @return true if organization-specific commonauth is enabled, false otherwise.
+     */
+    private boolean isOrgSpecificCommonAuthURLEnabled() {
+
+        if (getAuthenticatorConfig() == null || getAuthenticatorConfig().getParameterMap() == null) {
+            return false;
+        }
+
+        String value = getAuthenticatorConfig()
+                .getParameterMap()
+                .get(Office365AuthenticatorConstants.USE_ORG_SPECIFIC_COMMON_AUTH_URL);
+
+        return Boolean.parseBoolean(value);
+    }
+
+    /**
+     * Builds and returns the absolute public URL for the organization-specific commonauth endpoint.
+     *
+     * @return the organization-specific commonauth URL.
+     * @throws RuntimeException if URL building fails.
+     */
+    private String buildOrgSpecificCommonAuthURL() {
+
+        try {
+            return ServiceURLBuilder.create()
+                    .addPath(FrameworkConstants.COMMONAUTH)
+                    .build()
+                    .getAbsolutePublicURL();
+        } catch (URLBuilderException urlBuilderException) {
+            throw new RuntimeException("Error occurred while building the organization-specific commonauth URL.",
+                    urlBuilderException);
+        }
+    }
 }
-
-

--- a/component/src/main/java/org/wso2/carbon/identity/authenticator/office365/Office365AuthenticatorConstants.java
+++ b/component/src/main/java/org/wso2/carbon/identity/authenticator/office365/Office365AuthenticatorConstants.java
@@ -62,4 +62,5 @@ public class Office365AuthenticatorConstants {
 //    public static final String STATE = "state";
     //Additional Query Parameters that need to be sent to IDP
     public static final String ADDITIONAL_QUERY_PARAMS = "AdditionalQueryParameters";
+    public static final String USE_ORG_SPECIFIC_COMMON_AUTH_URL = "UseOrgSpecificCommonAuthURL";
 }

--- a/pom.xml
+++ b/pom.xml
@@ -192,8 +192,8 @@
                 <version>2.3.1</version>
                 <configuration>
                     <encoding>UTF-8</encoding>
-                    <source>1.7</source>
-                    <target>1.7</target>
+                    <source>1.8</source>
+                    <target>1.8</target>
                 </configuration>
             </plugin>
             <plugin>


### PR DESCRIPTION
## Purpose
When configuring authenticators such as Office365, the default Callback URL uses the standard /commonauth endpoint instead of an organization-specific commonauth endpoint. However, for standard OIDC connections, the default is the organization-specific commonauth endpoint.

This fix resolves the problem by ensuring that, when the callback property is not explicitly set, the proper org-specific commonauth URL is derived and used consistently.

Fixes: https://github.com/wso2/product-is/issues/24753

## Goals
- Ensure consistent usage of org-specific commonauth endpoints across authenticators when the callback property is not explicitly set.
- Reduce customer confusion and align behavior of Office365 and OIDC connections.

## Approach
- Updated the callback URL resolution logic so that when the callback property is empty in a sub-organization, the authenticator derives and uses the organization-specific commonauth endpoint.
- Introduced a new configuration parameter in deployment.toml:
```
[authentication.authenticator.office365.parameters]
UseOrgSpecificCommonAuthURL = true
```
- With this enabled, the authenticator defaults to https://<IS_DOMAIN>/o/<ORG_ID>/commonauth.
- Preserved existing behavior when the parameter is not configured, ensuring no disruption to current deployments.

## User stories
As an administrator configuring Office365 or OIDC authenticators under sub-organizations, I need the system to automatically resolve the correct org-specific commonauth endpoint so that authentication flows work consistently without manual intervention.

## Release note
Fixed an issue where authenticators did not resolve the correct org-specific commonauth endpoint when the callback property was empty, causing inconsistent behavior across authenticators.

## Documentation
N/A – No documentation impact as this change aligns authenticator behavior with existing documented behavior for OIDC connections.

## Training
N/A – No new functionality introduced; this is a fix for consistency.

## Certification
N/A – This fix does not introduce new product features requiring certification updates.

## Marketing
N/A – Internal consistency fix; not customer-facing feature addition.

## Security checks
 - Followed secure coding standards in http://wso2.com/technical-reports/wso2-secure-engineering-guidelines? yes 
 - Ran FindSecurityBugs plugin and verified report? yes 
 - Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets? yes

## Samples
N/A – Fix applies to existing authentication flows; no new samples required.

## Migrations (if applicable)
N/A – No migration impact.

## Test environment
JDK 11
macOS Sonoma 14.4
Databases: H2